### PR TITLE
Refactor PropTypes and move from View.propTypes to ViewPropTypes

### DIFF
--- a/Badge.js
+++ b/Badge.js
@@ -5,14 +5,13 @@
  * Copyright (c) 2016 react-native-component <moonsunfall@aliyun.com>
  */
 
-import React, {
-    Component,
-    PropTypes,
-} from 'react'
+import React, { Component } from 'react';
+import { PropTypes } from 'prop-types';
 import {
     View,
     Text,
     StyleSheet,
+    ViewPropTypes
 } from 'react-native'
 
 const styles = StyleSheet.create({
@@ -45,7 +44,7 @@ export default class Badge extends Component {
     static propTypes = {
         //borderRadius: PropTypes.number,   //number 18, null 5
         extraPaddingHorizontal: PropTypes.number,
-        style: View.propTypes.style,
+        style: ViewPropTypes.style,
         textStyle: Text.propTypes.style,
         minHeight: PropTypes.number,
         minWidth: PropTypes.number,

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 A smart autofit badge for react-native apps, written in JS for cross-platform support.
 It works on iOS and Android.
 
-This component is compatible with React Native 0.25 and newer.
+This component is compatible with React Native 0.49 and newer.
 
 ## Preview
 


### PR DESCRIPTION
…due to deprecated APIs breaking from RN 0.49 on; Update README to state new minimum RN version for lib; this fixes #5 